### PR TITLE
Update meta.json

### DIFF
--- a/data/zilliqa/assets/zil1qzwxvp3wz3q5ewzg3afesut9pqfax0sjdyna42/meta.json
+++ b/data/zilliqa/assets/zil1qzwxvp3wz3q5ewzg3afesut9pqfax0sjdyna42/meta.json
@@ -8,7 +8,7 @@
   "links": {
     "twitter": "https://twitter.com/MessiToken",
     "linkedin": "https://www.linkedin.com/company/messi-tokens",
-    "telegram": "https://t.me/RewardMessiTokens"
+    "telegram": "https://t.me/TheMessiProject"
   },
   "gen": {
     "logo": "logo.png",


### PR DESCRIPTION
We changed the TG group since we are no longer tied to Reward.

Balthazar, we need to remove anything related in the REWARD meta.json information.
I am not sure Angel will do it, but the:

-  site,
- email 
- team
- linkedin

Is no longer tied to us.

Thank you.