### PR TITLE
[Another Money] Remove governance token address

### DIFF
--- a/data/arweave/ecosystem/anothermoney/meta.json
+++ b/data/arweave/ecosystem/anothermoney/meta.json
@@ -6,8 +6,7 @@
     "coins"
   ],
   "addresses": [
-    "cYFdP90-GMYMVqL-Ev8KIx_p_tBjn7wQ4hSbAXkWW3g",
-    "rmx6a8XAVgGhzmjaBAsgjkCUFTzfvR0eGqqYs7ILGew"
+    "cYFdP90-GMYMVqL-Ev8KIx_p_tBjn7wQ4hSbAXkWW3g"
   ],
   "links": {
     "discord": "invite/pEVy4VD882",


### PR DESCRIPTION
If token has 2 and more addresses, it causes weird bug when token score becomes 0 even with correct score in assets folder presented.